### PR TITLE
qualcomm-qca9377: fix LICENSE

### DIFF
--- a/recipes-kernel/qualcomm-qca9377/qualcomm-qca9377.inc
+++ b/recipes-kernel/qualcomm-qca9377/qualcomm-qca9377.inc
@@ -2,6 +2,7 @@ SUMMARY = "8devices BLUE bean and RED bean drivers and firmware"
 SECTION = "networking"
 # explicitly states MODULE_LICENSE("Dual BSD/GPL")
 LICENSE = "GPL-2.0-or-later | BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://CORE/HDD/src/wlan_hdd_main.c;beginline=20511;endline=20511;md5=d3294313478278da0f1689534ae6f425"
 
 SRC_URI = "git://github.com/chargebyte/qcacld-2.0.git;protocol=https;branch=CNSS.LEA.NRT_3.0-i2se-kirkstone"
 SRCREV = "adcc3659f961fd535cd5dce55989e0393613ceaa"

--- a/recipes-kernel/qualcomm-qca9377/qualcomm-qca9377.inc
+++ b/recipes-kernel/qualcomm-qca9377/qualcomm-qca9377.inc
@@ -1,6 +1,7 @@
 SUMMARY = "8devices BLUE bean and RED bean drivers and firmware"
 SECTION = "networking"
-LICENSE = "CLOSED"
+# explicitly states MODULE_LICENSE("Dual BSD/GPL")
+LICENSE = "GPL-2.0-or-later | BSD-2-Clause"
 
 SRC_URI = "git://github.com/chargebyte/qcacld-2.0.git;protocol=https;branch=CNSS.LEA.NRT_3.0-i2se-kirkstone"
 SRCREV = "adcc3659f961fd535cd5dce55989e0393613ceaa"


### PR DESCRIPTION
The license is defined to "Dual BSD/GPL" in
https://github.com/8devices/qcacld-2.0/blob/CNSS.LEA.NRT_3.0/CORE/HDD/src/wlan_hdd_main.c#L20511
and
https://github.com/8devices/qcacld-2.0/blob/CNSS.LEA.NRT_3.0/CORE/SERVICES/HIF/USB/if_usb.c#L655.

It was explicitly changed in
https://github.com/8devices/qcacld-2.0/commit/1397cc135f39b1f4874fd3318bbc5dd6c3d9f412.

See also:
https://layers.openembedded.org/layerindex/recipe/99208/
This never even made it to thud (was probably dropped), and used old license strings.