### PR TITLE
Charge SOM: update U-Boot and Linux kernel

### DIFF
--- a/recipes-bsp/u-boot/chargesom.inc
+++ b/recipes-bsp/u-boot/chargesom.inc
@@ -1,4 +1,4 @@
-SRCBRANCH = "v2023.04_2.2.0-phy3-csom"
+SRCBRANCH = "v2024.04-2.0.0-phy6-csom"
 SRC_URI = "git://github.com/chargebyte/u-boot.git;protocol=https;branch=${SRCBRANCH}"
-SRCREV = "8747d69aed4ce24c5bff3f076285a2cea3e2886f"
+SRCREV = "fa9c2328a218990466c503f82b62b8385176d376"
 COMPATIBLE_MACHINE = "(mx93)"

--- a/recipes-kernel/linux/chargesom.inc
+++ b/recipes-kernel/linux/chargesom.inc
@@ -1,9 +1,9 @@
 # override kernel source
-SRCBRANCH = "v6.1.55_2.2.0-chargesom"
+SRCBRANCH = "v6.6.23-2.0.0-phy-cb"
 
 SRCREV = "${AUTOREV}"
 
-LINUX_VERSION = "6.1.55"
+LINUX_VERSION = "6.6.23"
 
 # Charge SOM has in-tree defconfig
 KBUILD_DEFCONFIG = "imx93-charge-som-dc-evb_defconfig"


### PR DESCRIPTION
This PR updates U-Boot and Linux kernel to newer versions,
both based on Phytec's [BSP-Yocto-NXP-i.MX93-PD24.2.0](https://phytec.github.io/doc-bsp-yocto/bsp/imx9/imx93/imx93.html#bsp-yocto-nxp-i-mx93-pd24-2-0).

Signed-off-by: Michael Heimpold <michael.heimpold@chargebyte.com>
