### PR TITLE
Charge SOM: add initial X11 overlays

### DIFF
--- a/conf/machine/chargesom.conf
+++ b/conf/machine/chargesom.conf
@@ -10,10 +10,12 @@ include conf/machine/include/imx-base.inc
 include conf/machine/include/arm/armv8-2a/tune-cortexa55.inc
 
 KERNEL_DEVICETREE = " \
+    freescale/imx93-charge-som-clko-gpio.dtbo \
     freescale/imx93-charge-som-dc-evb.dtb \
     freescale/imx93-charge-som-dc-evb-V0R1.dtb \
     freescale/imx93-charge-som-lvds-dd0700mc01.dtb \
     freescale/imx93-charge-som-lvds-dd0700mc01.dtbo \
+    freescale/imx93-charge-som-uart7.dtbo \
 "
 
 PREFERRED_PROVIDER_u-boot = "u-boot-imx"


### PR DESCRIPTION
This adds the two initial DT overlays for Charge SOM:
- imx93-charge-som-clko-gpio configures the 2 CLKO to GPIO
- imx93-charge-som-uart7 enables UART7 (without RTS/CTS)